### PR TITLE
gradients --> self.gradients

### DIFF
--- a/model.py
+++ b/model.py
@@ -163,7 +163,7 @@ class Model:
         optimizer = tf.train.AdamOptimizer(name="a_optimizer")
         self.grads, self.vars = zip(*optimizer.compute_gradients(self.loss))
         print("vars for loss function: ", self.vars)
-        gradients, _ = tf.clip_by_global_norm(self.grads, 5)  # clip gradients
+        self.gradients, _ = tf.clip_by_global_norm(self.grads, 5)  # clip gradients
         self.train_op = optimizer.apply_gradients(zip(self.gradients, self.vars))
         # self.train_op = optimizer.minimize(self.loss)
         # train_op = layers.optimize_loss(


### PR DESCRIPTION
The recent pull request contained an error that caused this exception:
```
Traceback (most recent call last):
  File "main.py", line 143, in <module>
    train()
  File "main.py", line 30, in train
    model = get_model()
  File "main.py", line 25, in get_model
    model.build()
  File "/home/martino/tesi/RNN-for-Joint-NLU/model.py", line 167, in build
    self.train_op = optimizer.apply_gradients(zip(self.gradients, self.vars))
AttributeError: 'Model' object has no attribute 'gradients'
```
Adding `self.` fixes back the code